### PR TITLE
Automatically pick the calver when making a release.

### DIFF
--- a/Tools/Release/Package.swift
+++ b/Tools/Release/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     products: [.executable(name: "release", targets: ["Release"])],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
-        .package(url: "https://github.com/element-hq/swift-command-line-tools.git", revision: "e5eaab1558ef664e6cd80493f64259381670fb3a")
+        .package(url: "https://github.com/element-hq/swift-command-line-tools.git", revision: "c085ad85c27970e4bba2dd1180c2a53ab77022ba")
         // .package(path: "../../../swift-command-line-tools")
     ],
     targets: [

--- a/Tools/Release/README.md
+++ b/Tools/Release/README.md
@@ -5,10 +5,10 @@ Creates a Github release from a matrix-rust-sdk repository.
 
 Usage:
 ```
-swift run release --version v1.0.18-alpha
+swift run release    # e.g. version 25.12.31
 ```
 
-For help: `swift run release --help`
+For help (including how to customise the version): `swift run release --help`
 
 ## Requirements
 

--- a/Tools/Release/Sources/Release.swift
+++ b/Tools/Release/Sources/Release.swift
@@ -5,7 +5,14 @@ import Foundation
 @main
 struct Release: AsyncParsableCommand {
     @Option(help: "The version of the package that is being released.")
-    var version: String
+    var buildNumber: Int? = nil
+    
+    @Option(help: "A custom version to use instead of generating a calendar version.")
+    var customVersion: String? = nil
+    
+    var version: String {
+        customVersion ?? Date.now.calendarVersion(buildNumber: buildNumber)
+    }
     
     @Flag(help: "Prevents the run from pushing anything to GitHub.")
     var localOnly = false

--- a/Tools/Release/Sources/Release.swift
+++ b/Tools/Release/Sources/Release.swift
@@ -4,10 +4,10 @@ import Foundation
 
 @main
 struct Release: AsyncParsableCommand {
-    @Option(help: "The version of the package that is being released.")
+    @Option(help: "An optional build number that will be appended to the generated version (e.g. 25.12.31-123). This option is ignored when a custom version is specified.")
     var buildNumber: Int? = nil
     
-    @Option(help: "A custom version to use instead of generating a calendar version.")
+    @Option(help: "A custom version to use instead of generating a calendar version. This option takes precedence over --build-number.")
     var customVersion: String? = nil
     
     var version: String {


### PR DESCRIPTION
Please also check https://github.com/element-hq/swift-command-line-tools/commit/c085ad85c27970e4bba2dd1180c2a53ab77022ba for the implementation of `Date.calendarVersion`.