### PR TITLE
Switch to using the new apple-release profile for distribution

### DIFF
--- a/Tools/Release/Sources/Release.swift
+++ b/Tools/Release/Sources/Release.swift
@@ -55,7 +55,7 @@ struct Release: AsyncParsableCommand {
         Log.info("Building \(branch) at \(commitHash)")
         
         // unset fixes an issue where swift compilation prevents building for targets other than macOS
-        let cargoCommand = "cargo xtask swift build-framework --release --target aarch64-apple-ios --target aarch64-apple-ios-sim --target x86_64-apple-ios"
+        let cargoCommand = "cargo xtask swift build-framework --profile apple-release --target aarch64-apple-ios --target aarch64-apple-ios-sim --target x86_64-apple-ios"
         try Zsh.run(command: "unset SDKROOT && \(cargoCommand)", directory: buildDirectory)
         
         return BuildProduct(sourceRepo: sourceRepo,


### PR DESCRIPTION
in the hope of smaller binary sizes

Counterpart to https://github.com/matrix-org/matrix-rust-sdk/pull/6714